### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/rexbrahh/sydradb/security/code-scanning/1](https://github.com/rexbrahh/sydradb/security/code-scanning/1)

To remediate, an explicit `permissions` block should be added to the workflow or specific job(s) that reflects the minimum privilege required. Since the current workflow performs only building, testing, and pre-commit checks (no steps require token writes or administrative actions), the minimal necessary permission is likely just `contents: read`. This can be set at the top (workflow level, before `jobs:`) so it applies to all jobs, unless a specific job must override with a different set. Edit `.github/workflows/ci.yml` by adding the following block after the workflow name and before `on:` or `jobs:`:

```yaml
permissions:
  contents: read
```

No other imports or code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
